### PR TITLE
Add UI option for Chinese speech recognition

### DIFF
--- a/python/api/transcribe.py
+++ b/python/api/transcribe.py
@@ -12,5 +12,10 @@ class Transcribe(ApiHandler):
         #     context.log.log(type="info", content="Whisper STT model is currently being initialized, please wait...")
 
         set = settings.get_settings()
-        result = await whisper.transcribe(set["stt_model_size"], audio) # type: ignore
+        requested_language = input.get("language")
+        language = str(requested_language).strip() if requested_language else ""
+        if not language:
+            language = set["stt_language"]
+
+        result = await whisper.transcribe(set["stt_model_size"], audio, language=language) # type: ignore
         return result

--- a/python/helpers/settings.py
+++ b/python/helpers/settings.py
@@ -991,13 +991,40 @@ def convert_out(settings: Settings) -> SettingsOutput:
         }
     )
 
+    stt_language_value = str(settings["stt_language"]).strip()
+    stt_language_value_lower = stt_language_value.lower()
+    if stt_language_value_lower in ("", "auto"):
+        stt_language_mode = "auto"
+    elif stt_language_value_lower == "en":
+        stt_language_mode = "en"
+    elif stt_language_value_lower.startswith("zh"):
+        stt_language_mode = "zh"
+    else:
+        stt_language_mode = "custom"
+
+    stt_fields.append(
+        {
+            "id": "stt_language_mode",
+            "title": "Speech-to-text language",
+            "description": "Choose the transcription language. Select Custom to provide your own language code.",
+            "type": "select",
+            "value": stt_language_mode,
+            "options": [
+                {"value": "auto", "label": "Auto-detect"},
+                {"value": "en", "label": "English"},
+                {"value": "zh", "label": "中文 (Chinese)"},
+                {"value": "custom", "label": "Custom"},
+            ],
+        }
+    )
+
     stt_fields.append(
         {
             "id": "stt_language",
             "title": "Speech-to-text language code",
-            "description": "Language code (e.g. en, fr, it)",
+            "description": "Current language code. Enter a value when using the Custom option above (e.g. en, fr, zh-Hans).",
             "type": "text",
-            "value": settings["stt_language"],
+            "value": stt_language_value,
         }
     )
 
@@ -1290,6 +1317,8 @@ def _get_api_key_field(settings: Settings, provider: str, title: str) -> Setting
 
 def convert_in(settings: dict) -> Settings:
     current = get_settings()
+    stt_language_mode: str | None = None
+    stt_language_value: str | None = None
     for section in settings["sections"]:
         if "fields" in section:
             for field in section["fields"]:
@@ -1303,10 +1332,32 @@ def convert_in(settings: dict) -> Settings:
                     # Special handling for browser_http_headers
                     if field["id"] == "browser_http_headers" or field["id"].endswith("_kwargs"):
                         current[field["id"]] = _env_to_dict(field["value"])
+                    elif field["id"] == "stt_language_mode":
+                        stt_language_mode = str(field["value"])
+                        continue
+                    elif field["id"] == "stt_language":
+                        stt_language_value = str(field["value"])
+                        continue
                     elif field["id"].startswith("api_key_"):
                         current["api_keys"][field["id"]] = field["value"]
                     else:
                         current[field["id"]] = field["value"]
+
+    selected_mode = (stt_language_mode or "").strip().lower()
+    custom_value_raw = (stt_language_value or "").strip()
+    custom_value = custom_value_raw.lower() if custom_value_raw else ""
+
+    if selected_mode:
+        if selected_mode == "custom":
+            if custom_value:
+                current["stt_language"] = custom_value
+        elif selected_mode == "auto":
+            current["stt_language"] = "auto"
+        else:
+            current["stt_language"] = selected_mode
+    elif stt_language_value is not None:
+        # When only the raw language value is provided (e.g. legacy clients)
+        current["stt_language"] = custom_value
     return current
 
 def get_settings() -> Settings:

--- a/python/helpers/whisper.py
+++ b/python/helpers/whisper.py
@@ -69,12 +69,12 @@ async def is_downloaded():
 def _is_downloaded():
     return _model is not None
 
-async def transcribe(model_name:str, audio_bytes_b64: str):
-    # return await runtime.call_development_function(_transcribe, model_name, audio_bytes_b64)
-    return await _transcribe(model_name, audio_bytes_b64)
+async def transcribe(model_name:str, audio_bytes_b64: str, language: str | None = None):
+    # return await runtime.call_development_function(_transcribe, model_name, audio_bytes_b64, language)
+    return await _transcribe(model_name, audio_bytes_b64, language)
 
 
-async def _transcribe(model_name:str, audio_bytes_b64: str):
+async def _transcribe(model_name:str, audio_bytes_b64: str, language: str | None = None):
     await _preload(model_name)
     
     # Decode audio bytes if encoded as a base64 string
@@ -87,7 +87,12 @@ async def _transcribe(model_name:str, audio_bytes_b64: str):
         temp_path = audio_file.name
     try:
         # Transcribe the audio file
-        result = _model.transcribe(temp_path, fp16=False) # type: ignore
+        transcription_kwargs = {"fp16": False}
+        language_normalized = (language or "").strip().lower()
+        if language_normalized and language_normalized not in {"auto", "default"}:
+            transcription_kwargs["language"] = language_normalized
+
+        result = _model.transcribe(temp_path, **transcription_kwargs) # type: ignore
         return result
     finally:
         try:

--- a/webui/components/chat/speech/speech-store.js
+++ b/webui/components/chat/speech/speech-store.js
@@ -871,7 +871,10 @@ class MicrophoneInput {
     const base64 = await this.convertBlobToBase64Wav(audioBlob);
 
     try {
-      const result = await sendJsonData("/transcribe", { audio: base64 });
+      const result = await sendJsonData("/transcribe", {
+        audio: base64,
+        language: store.stt_language,
+      });
       const text = this.filterResult(result.text || "");
 
       if (text) {


### PR DESCRIPTION
## Summary
- add a selectable speech-to-text language option in the settings, including a Chinese preset and support for custom codes
- ensure saved settings map back to the stored language preference while keeping legacy compatibility
- forward the chosen language through the transcription API and Whisper helper so browser recordings use the configured locale

## Testing
- pytest *(fails: environment missing python package import path for tests and OPENAI_API_KEY for litellm)*

------
https://chatgpt.com/codex/tasks/task_e_68e4e7c9fea88329b6f273ed6696cc38